### PR TITLE
fix: parallel tests are skipped due to differences in sort order

### DIFF
--- a/src/main/java/net/serenitybdd/cucumber/suiteslicing/WeightedCucumberScenarios.java
+++ b/src/main/java/net/serenitybdd/cucumber/suiteslicing/WeightedCucumberScenarios.java
@@ -1,7 +1,5 @@
 package net.serenitybdd.cucumber.suiteslicing;
 
-import com.google.common.collect.Iterables;
-
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.slf4j.Logger;
@@ -16,7 +14,6 @@ import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
 import static java.math.BigDecimal.ZERO;
-import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.ObjectUtils.compare;
 import static org.apache.commons.lang3.builder.EqualsBuilder.reflectionEquals;
@@ -49,7 +46,7 @@ public class WeightedCucumberScenarios {
         List<List<WeightedCucumberScenario>> allScenarios = IntStream.rangeClosed(1, sliceCount).mapToObj(initialiseAs -> new ArrayList<WeightedCucumberScenario>()).collect(toList());
 
         scenarios.stream()
-            .sorted(bySlowestFirst())
+            .sorted(bySlowestFirst().thenComparing(byFeaturePathAscending()))
             .forEach(scenario -> allScenarios.stream().min(byLowestSumOfDurationFirst()).get().add(scenario));
 
         return allScenarios.stream().map(WeightedCucumberScenarios::new).collect(toList());
@@ -93,6 +90,13 @@ public class WeightedCucumberScenarios {
 
     private static Comparator<WeightedCucumberScenario> bySlowestFirst() {
         return (item1, item2) -> compare(item2.weighting(), item1.weighting());
+    }
+
+    /** Ensure the order of scenarios with the same weighting. This is to prevent scenarios getting skipped from
+     * batch or fork. Use featurePath due to unique file name.
+     * */
+    private static Comparator<WeightedCucumberScenario> byFeaturePathAscending() {
+        return (item1, item2) -> compare(item1.featurePath, item2.featurePath);
     }
 
     private static Comparator<List<WeightedCucumberScenario>> byLowestSumOfDurationFirst() {

--- a/src/test/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoaderTest.java
+++ b/src/test/java/net/serenitybdd/cucumber/suiteslicing/CucumberScenarioLoaderTest.java
@@ -4,11 +4,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 
 public class CucumberScenarioLoaderTest {
@@ -58,5 +60,39 @@ public class CucumberScenarioLoaderTest {
                                                                     .feature("Tagged Tables")
                                                                     .scenario("This scenario should have two tables")
                                                                     .tags("@small", "@big")));
+    }
+
+    @Test
+    public void scenariosOfAllSlicesBetweenAllJvmShouldBeTheSame() throws URISyntaxException {
+        List<URI> featurePaths = newArrayList(new URI("classpath:samples/feature_pending_tag.feature"),
+            new URI("classpath:samples/multiple_jira_issues.feature"),
+            new URI("classpath:samples/multiple_scenarios.feature"),
+            new URI("classpath:samples/scenario_with_table_in_background_steps.feature"),
+            new URI("classpath:samples/tagged_example_tables.feature"));
+        int sliceCount = 5;
+
+        List<WeightedCucumberScenarios> jvm1Slices = new CucumberScenarioLoader(featurePaths, new DummyStatsOfWeightingOne()).load()
+            .sliceInto(sliceCount);
+
+        List<WeightedCucumberScenarios> jvm2Slices = new CucumberScenarioLoader(featurePaths, new DummyStatsOfWeightingOne()).load()
+            .sliceInto(sliceCount);
+
+        for (int i = 0; i < jvm1Slices.size(); i++) {
+            assertThat(jvm1Slices.get(i).scenarios, contains(buildMatchingCucumberScenario(jvm2Slices.get(i))));
+        }
+    }
+
+    private MatchingCucumberScenario[] buildMatchingCucumberScenario(WeightedCucumberScenarios weightedCucumberScenarios) {
+        List<MatchingCucumberScenario> list = new ArrayList<>();
+        weightedCucumberScenarios.scenarios.forEach(s -> {
+            MatchingCucumberScenario match = MatchingCucumberScenario.with()
+                .feature(s.feature)
+                .featurePath(s.featurePath)
+                .scenario(s.scenario);
+
+            list.add(match);
+        });
+
+        return list.toArray(new MatchingCucumberScenario[list.size()]);
     }
 }


### PR DESCRIPTION
Same fix as serenity-bdd/serenity-cucumber5#19. 