### PR TITLE
Fix ScenarioFilter for Scenario Outline batch run

### DIFF
--- a/src/main/java/net/serenitybdd/cucumber/suiteslicing/ScenarioFilter.java
+++ b/src/main/java/net/serenitybdd/cucumber/suiteslicing/ScenarioFilter.java
@@ -32,7 +32,7 @@ public class ScenarioFilter extends Filter {
     @Override
     public boolean shouldRun(Description description) {
         String displayName = description.getDisplayName();
-        String methodName = description.getMethodName();
+        String methodName = description.getMethodName().replaceAll(" #\\d+$",""); //For scenario outline method name contains #X where X is row number
         boolean shouldRun = scenarios.stream().anyMatch(methodName::equals) || displayName.startsWith("Examples") || displayName.contains("|");
         LOGGER.debug("Test should run: {} step: {}", shouldRun, description.getDisplayName());
         if (shouldRun) {


### PR DESCRIPTION
When using batch run all scenario outlines are filtered out because they do not match as they contain at the method name # with row number

This change removes this # from method name and allows scenario to be run