### PR TITLE
junit cleanup to make useable with cucumber-junit-platform-engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,18 +121,16 @@ configurations.all {
 
 dependencies {
     compile("net.serenity-bdd:serenity-core:${serenityCoreVersion}")
-    compile("net.serenity-bdd:serenity-screenplay:${serenityCoreVersion}")
-    compile("net.serenity-bdd:serenity-screenplay-webdriver:${serenityCoreVersion}")
+    compileOnly("net.serenity-bdd:serenity-screenplay:${serenityCoreVersion}")
+    testCompile("net.serenity-bdd:serenity-screenplay-webdriver:${serenityCoreVersion}")
     compile "io.cucumber:cucumber-java:${cucumberJVMVersion}"
-    compile("io.cucumber:cucumber-junit:${cucumberJVMVersion}") {
+    implementation("io.cucumber:cucumber-junit:${cucumberJVMVersion}") {
         exclude group: "junit"
     }
-    compile "io.cucumber:datatable-matchers:${cucumberDatatableMatchers}"
+    testCompile "io.cucumber:datatable-matchers:${cucumberDatatableMatchers}"
 
-    compile("commons-logging:commons-logging:${commonsLoggingVersion}")
-    compile("org.apache.commons:commons-csv:${commonsCsvVersion}")
-    compile "junit:junit:${junitVersion}"
-    compile "com.google.code.gson:gson:${gsonVersion}"
+    implementation("org.apache.commons:commons-csv:${commonsCsvVersion}")
+    implementation "junit:junit:${junitVersion}"
 
     testCompile("ch.qos.logback:logback-classic:${logbackVersion}") {
         exclude module: "slf4j-api"
@@ -153,7 +151,7 @@ dependencies {
 
 jar {
     manifest {
-        attributes("Implementation-Title": "Serenity Cucumber 5 Plugin",
+        attributes("Implementation-Title": "Serenity Cucumber 6 Plugin",
                    "Implementation-Version": project.version.toString())
     }
 }

--- a/src/main/java/io/cucumber/core/plugin/LineFilters.java
+++ b/src/main/java/io/cucumber/core/plugin/LineFilters.java
@@ -3,7 +3,7 @@ package io.cucumber.core.plugin;
 
 import io.cucumber.messages.Messages.GherkinDocument.Feature.Scenario.Examples;
 import io.cucumber.messages.Messages.GherkinDocument.Feature.TableRow;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -30,7 +30,7 @@ public class LineFilters {
     }
 
     private Map<URI, Set<Integer>> newLineFilters() {
-        Map<URI, Set<Integer>> lineFiltersFromRuntime = CucumberWithSerenity.currentRuntimeOptions().getLineFilters();
+        Map<URI, Set<Integer>> lineFiltersFromRuntime = CucumberWithSerenityRuntime.currentRuntimeOptions().getLineFilters();
         if (lineFiltersFromRuntime == null) {
             return new HashMap<>();
         } else {

--- a/src/main/java/io/cucumber/core/plugin/SerenityReporter.java
+++ b/src/main/java/io/cucumber/core/plugin/SerenityReporter.java
@@ -895,7 +895,11 @@ public class SerenityReporter implements Plugin, ConcurrentEventListener {
     }
 
     private boolean isAssumptionFailure(Throwable rootCause) {
-        return ("org.junit.internal.AssumptionViolatedException".equals(rootCause.getClass().getCanonicalName()));
+    	try {
+			return (Class.forName("org.junit.internal.AssumptionViolatedException").isAssignableFrom(rootCause.getClass()));
+		} catch (ClassNotFoundException e) {
+			return false;
+		}
     }
 
     private String stepTitleFrom(Step currentStep, io.cucumber.plugin.event.TestStep testStep) {

--- a/src/main/java/io/cucumber/core/plugin/SerenityReporter.java
+++ b/src/main/java/io/cucumber/core/plugin/SerenityReporter.java
@@ -16,7 +16,7 @@ import io.cucumber.tagexpressions.Expression;
 import net.serenitybdd.core.Serenity;
 import net.serenitybdd.core.SerenityListeners;
 import net.serenitybdd.core.SerenityReports;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 import net.serenitybdd.cucumber.formatting.ScenarioOutlineDescription;
 import net.serenitybdd.cucumber.util.PathUtils;
 import net.serenitybdd.cucumber.util.StepDefinitionAnnotationReader;
@@ -493,10 +493,10 @@ public class SerenityReporter implements Plugin, ConcurrentEventListener {
     }
 
     private List<Expression> getCucumberRuntimeTags() {
-        if (CucumberWithSerenity.currentRuntimeOptions() == null) {
+        if (CucumberWithSerenityRuntime.currentRuntimeOptions() == null) {
             return new ArrayList<>();
         } else {
-            return CucumberWithSerenity.currentRuntimeOptions().getTagExpressions();
+            return CucumberWithSerenityRuntime.currentRuntimeOptions().getTagExpressions();
         }
     }
 

--- a/src/main/java/io/cucumber/core/plugin/SerenityReporter.java
+++ b/src/main/java/io/cucumber/core/plugin/SerenityReporter.java
@@ -8,7 +8,7 @@ import io.cucumber.messages.Messages.GherkinDocument.Feature.TableRow;
 import io.cucumber.messages.Messages.GherkinDocument.Feature.TableRow.TableCell;
 import io.cucumber.messages.Messages.GherkinDocument.Feature.Scenario.Examples;
 import io.cucumber.messages.Messages.GherkinDocument.Feature.Tag;
-import io.cucumber.messages.Messages.GherkinDocument.Feature.Step;;
+import io.cucumber.messages.Messages.GherkinDocument.Feature.Step;
 import io.cucumber.plugin.ConcurrentEventListener;
 import io.cucumber.plugin.Plugin;
 import io.cucumber.plugin.event.*;
@@ -32,7 +32,6 @@ import net.thucydides.core.webdriver.Configuration;
 import net.thucydides.core.webdriver.ThucydidesWebDriverSupport;
 import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
-import org.junit.internal.AssumptionViolatedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -896,7 +895,7 @@ public class SerenityReporter implements Plugin, ConcurrentEventListener {
     }
 
     private boolean isAssumptionFailure(Throwable rootCause) {
-        return (AssumptionViolatedException.class.isAssignableFrom(rootCause.getClass()));
+        return ("org.junit.internal.AssumptionViolatedException".equals(rootCause.getClass().getCanonicalName()));
     }
 
     private String stepTitleFrom(Step currentStep, io.cucumber.plugin.event.TestStep testStep) {

--- a/src/main/java/io/cucumber/junit/CucumberSerenityRunner.java
+++ b/src/main/java/io/cucumber/junit/CucumberSerenityRunner.java
@@ -14,14 +14,13 @@ import io.cucumber.core.runtime.Runtime;
 import io.cucumber.core.runtime.*;
 import io.cucumber.plugin.Plugin;
 import io.cucumber.tagexpressions.Expression;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 import net.serenitybdd.cucumber.SerenityOptions;
 import net.serenitybdd.cucumber.suiteslicing.CucumberSuiteSlicer;
 import net.serenitybdd.cucumber.suiteslicing.ScenarioFilter;
 import net.serenitybdd.cucumber.suiteslicing.TestStatistics;
 import net.serenitybdd.cucumber.suiteslicing.WeightedCucumberScenarios;
 import net.serenitybdd.cucumber.util.PathUtils;
-import net.serenitybdd.cucumber.util.Splitter;
-import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.steps.StepEventBus;
 import net.thucydides.core.util.EnvironmentVariables;
@@ -60,39 +59,12 @@ public class CucumberSerenityRunner extends ParentRunner<ParentRunner<?>> {
 
     private List<ParentRunner<?>> children = new ArrayList<ParentRunner<?>>();
     private final EventBus bus;
-    private static ThreadLocal<RuntimeOptions> RUNTIME_OPTIONS = new ThreadLocal<>();
 
     private final List<Feature> features;
     private final Plugins plugins;
     private final CucumberExecutionContext context;
 
     private boolean multiThreadingAssumed = false;
-
-    private static RuntimeOptions buildRuntimeOptions(Function<RuntimeOptions, RuntimeOptions> configurer) {
-        RuntimeOptions propertiesFileOptions = new CucumberPropertiesParser()
-                .parse(CucumberProperties.fromPropertiesFile())
-                .build();
-
-        RuntimeOptions annotationOptions = configurer != null ?
-        		configurer.apply(propertiesFileOptions) : propertiesFileOptions;
-
-        RuntimeOptions environmentOptions = new CucumberPropertiesParser()
-                .parse(CucumberProperties.fromEnvironment())
-                .build(annotationOptions);
-
-        RuntimeOptions runtimeOptions = new CucumberPropertiesParser()
-                .parse(CucumberProperties.fromSystemProperties())
-                .addDefaultSummaryPrinterIfAbsent()
-                .build(environmentOptions);
-
-        RuntimeOptionsBuilder runtimeOptionsBuilder = new RuntimeOptionsBuilder();
-        Collection<String> tagFilters = environmentSpecifiedTags(runtimeOptions.getTagExpressions());
-        for (String tagFilter : tagFilters) {
-            runtimeOptionsBuilder.addTagFilter(new LiteralExpression(tagFilter));
-        }
-        runtimeOptionsBuilder.build(runtimeOptions);
-        return runtimeOptions;
-    }
 
     /**
      * Constructor called by JUnit.
@@ -105,7 +77,7 @@ public class CucumberSerenityRunner extends ParentRunner<ParentRunner<?>> {
         Assertions.assertNoCucumberAnnotatedMethods(clazz);
 
         // Parse the options early to provide fast feedback about invalid options
-        RuntimeOptions runtimeOptions = buildRuntimeOptions(
+        RuntimeOptions runtimeOptions = CucumberWithSerenityRuntime.buildRuntimeOptions(
         		propertiesFileOptions -> new CucumberOptionsAnnotationParser()
                 .withOptionsProvider(new JUnitCucumberOptionsProvider())
                 .parse(clazz)
@@ -131,7 +103,7 @@ public class CucumberSerenityRunner extends ParentRunner<ParentRunner<?>> {
 
         this.bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
 
-        setRuntimeOptions(runtimeOptions);
+        CucumberWithSerenityRuntime.setRuntimeOptions(runtimeOptions);
 
         // Parse the features early. Don't proceed when there are lexer errors
         FeatureParser parser = new FeatureParser(bus::generateId);
@@ -187,62 +159,6 @@ public class CucumberSerenityRunner extends ParentRunner<ParentRunner<?>> {
     }
 
 
-
-    private static RuntimeOptions DEFAULT_RUNTIME_OPTIONS = buildRuntimeOptions(null);
-
-    public static void setRuntimeOptions(RuntimeOptions runtimeOptions) {
-        RUNTIME_OPTIONS.set(runtimeOptions);
-    }
-
-    public static RuntimeOptions currentRuntimeOptions() {
-        return (RUNTIME_OPTIONS.get() != null) ? RUNTIME_OPTIONS.get() : DEFAULT_RUNTIME_OPTIONS;
-    }
-
-    private static Collection<String> environmentSpecifiedTags(List<?> existingTags) {
-        EnvironmentVariables environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
-        String tagsExpression = ThucydidesSystemProperty.TAGS.from(environmentVariables, "");
-        List<String> existingTagsValues = existingTags.stream().map(Object::toString).collect(toList());
-        return Splitter.on(",").trimResults().omitEmptyStrings().splitToList(tagsExpression).stream()
-                .map(CucumberSerenityRunner::toCucumberTag).filter(t -> !existingTagsValues.contains(t)).collect(toList());
-    }
-
-    private static String toCucumberTag(String from) {
-        String tag = from.replaceAll(":", "=");
-        if (tag.startsWith("~@") || tag.startsWith("@")) {
-            return tag;
-        }
-        if (tag.startsWith("~")) {
-            return "~@" + tag.substring(1);
-        }
-
-        return "@" + tag;
-    }
-
-    public static Runtime createSerenityEnabledRuntime(/*ResourceLoader resourceLoader,*/
-            Supplier<ClassLoader> classLoaderSupplier,
-            RuntimeOptions runtimeOptions,
-            Configuration systemConfiguration) {
-        RuntimeOptionsBuilder runtimeOptionsBuilder = new RuntimeOptionsBuilder();
-        Collection<String> allTagFilters = environmentSpecifiedTags(runtimeOptions.getTagExpressions());
-        for (String tagFilter : allTagFilters) {
-            runtimeOptionsBuilder.addTagFilter(new LiteralExpression(tagFilter));
-        }
-        runtimeOptionsBuilder.build(runtimeOptions);
-        setRuntimeOptions(runtimeOptions);
-
-
-        EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
-        FeatureParser parser = new FeatureParser(bus::generateId);
-        FeaturePathFeatureSupplier featureSupplier = new FeaturePathFeatureSupplier(classLoaderSupplier, runtimeOptions, parser);
-
-        SerenityReporter serenityReporter = new SerenityReporter(systemConfiguration);
-        Runtime runtime = Runtime.builder().withClassLoader(classLoaderSupplier).withRuntimeOptions(runtimeOptions).
-                withAdditionalPlugins(serenityReporter).
-                withEventBus(bus).withFeatureSupplier(featureSupplier).
-                build();
-
-        return runtime;
-    }
 
     private static void addSerenityReporterPlugin(Plugins plugins, SerenityReporter plugin) {
         for (Plugin currentPlugin : plugins.getPlugins()) {
@@ -308,7 +224,7 @@ public class CucumberSerenityRunner extends ParentRunner<ParentRunner<?>> {
     public List<ParentRunner<?>> getChildren() {
         try {
             EnvironmentVariables environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
-            RuntimeOptions runtimeOptions = currentRuntimeOptions();
+            RuntimeOptions runtimeOptions = CucumberWithSerenityRuntime.currentRuntimeOptions();
             List<Expression> tagFilters = runtimeOptions.getTagExpressions();
             List<URI> featurePaths = runtimeOptions.getFeaturePaths();
             int batchNumber = environmentVariables.getPropertyAsInteger(SERENITY_BATCH_NUMBER, 1);

--- a/src/main/java/net/serenitybdd/cucumber/CucumberWithSerenityRuntime.java
+++ b/src/main/java/net/serenitybdd/cucumber/CucumberWithSerenityRuntime.java
@@ -1,12 +1,29 @@
 package net.serenitybdd.cucumber;
 
 
+import io.cucumber.core.eventbus.EventBus;
+import io.cucumber.core.feature.FeatureParser;
+import io.cucumber.core.options.CucumberProperties;
+import io.cucumber.core.options.CucumberPropertiesParser;
 import io.cucumber.core.options.RuntimeOptions;
+import io.cucumber.core.options.RuntimeOptionsBuilder;
 import io.cucumber.core.plugin.SerenityReporter;
+import io.cucumber.core.runtime.FeaturePathFeatureSupplier;
 import io.cucumber.core.runtime.Runtime;
+import io.cucumber.core.runtime.TimeServiceEventBus;
+import net.serenitybdd.cucumber.util.Splitter;
+import net.thucydides.core.ThucydidesSystemProperty;
 import net.thucydides.core.guice.Injectors;
+import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.webdriver.Configuration;
 
+import static java.util.stream.Collectors.toList;
+
+import java.time.Clock;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 
@@ -19,18 +36,92 @@ public class CucumberWithSerenityRuntime {
     }
 
 
-    private static Runtime createSerenityEnabledRuntime(Supplier<ClassLoader> classLoaderSupplier,
-                                                        RuntimeOptions runtimeOptions,
-                                                        Configuration systemConfiguration) {
-        //ClassFinder resolvedClassFinder = Optional.ofNullable(classFinder).orElse(new ResourceLoaderClassFinder(resourceLoader, classLoader));
-        SerenityReporter reporter = new SerenityReporter(systemConfiguration);
-        //Runtime runtime = Runtime.builder().withResourceLoader(resourceLoader).withClassFinder(resolvedClassFinder).
-        //        withClassLoader(classLoader).withRuntimeOptions(runtimeOptions).withAdditionalPlugins(reporter).build();
+	public static Runtime createSerenityEnabledRuntime(/*ResourceLoader resourceLoader,*/
+	        Supplier<ClassLoader> classLoaderSupplier,
+	        RuntimeOptions runtimeOptions,
+	        Configuration systemConfiguration) {
+	    RuntimeOptionsBuilder runtimeOptionsBuilder = new RuntimeOptionsBuilder();
+	    Collection<String> allTagFilters = environmentSpecifiedTags(runtimeOptions.getTagExpressions());
+	    for (String tagFilter : allTagFilters) {
+	        runtimeOptionsBuilder.addTagFilter(new LiteralExpression(tagFilter));
+	    }
+	    runtimeOptionsBuilder.build(runtimeOptions);
+	    setRuntimeOptions(runtimeOptions);
+	
+	
+	    EventBus bus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
+	    FeatureParser parser = new FeatureParser(bus::generateId);
+	    FeaturePathFeatureSupplier featureSupplier = new FeaturePathFeatureSupplier(classLoaderSupplier, runtimeOptions, parser);
+	
+	    SerenityReporter serenityReporter = new SerenityReporter(systemConfiguration);
+	    Runtime runtime = Runtime.builder().withClassLoader(classLoaderSupplier).withRuntimeOptions(runtimeOptions).
+	            withAdditionalPlugins(serenityReporter).
+	            withEventBus(bus).withFeatureSupplier(featureSupplier).
+	            build();
+	
+	    return runtime;
+	}
 
-        Runtime runtime = Runtime.builder().
-                withClassLoader(classLoaderSupplier).
-                withRuntimeOptions(runtimeOptions).
-                withAdditionalPlugins(reporter).build();
-        return runtime;
-    }
+	public static ThreadLocal<RuntimeOptions> RUNTIME_OPTIONS = new ThreadLocal<>();
+	public static RuntimeOptions DEFAULT_RUNTIME_OPTIONS = buildRuntimeOptions(null);
+
+
+	public static RuntimeOptions buildRuntimeOptions(Function<RuntimeOptions, RuntimeOptions> configurer) {
+	    RuntimeOptions propertiesFileOptions = new CucumberPropertiesParser()
+	            .parse(CucumberProperties.fromPropertiesFile())
+	            .build();
+	
+	    RuntimeOptions annotationOptions = configurer != null ?
+	    		configurer.apply(propertiesFileOptions) : propertiesFileOptions;
+	
+	    RuntimeOptions environmentOptions = new CucumberPropertiesParser()
+	            .parse(CucumberProperties.fromEnvironment())
+	            .build(annotationOptions);
+	
+	    RuntimeOptions runtimeOptions = new CucumberPropertiesParser()
+	            .parse(CucumberProperties.fromSystemProperties())
+	            .addDefaultSummaryPrinterIfAbsent()
+	            .build(environmentOptions);
+	
+	    RuntimeOptionsBuilder runtimeOptionsBuilder = new RuntimeOptionsBuilder();
+	    Collection<String> tagFilters = environmentSpecifiedTags(runtimeOptions.getTagExpressions());
+	    for (String tagFilter : tagFilters) {
+	        runtimeOptionsBuilder.addTagFilter(new LiteralExpression(tagFilter));
+	    }
+	    runtimeOptionsBuilder.build(runtimeOptions);
+	    return runtimeOptions;
+	}
+
+
+	public static void setRuntimeOptions(RuntimeOptions runtimeOptions) {
+	    RUNTIME_OPTIONS.set(runtimeOptions);
+	}
+
+
+	public static RuntimeOptions currentRuntimeOptions() {
+	    return (RUNTIME_OPTIONS.get() != null) ? RUNTIME_OPTIONS.get() : DEFAULT_RUNTIME_OPTIONS;
+	}
+
+
+	private static Collection<String> environmentSpecifiedTags(List<?> existingTags) {
+	    EnvironmentVariables environmentVariables = Injectors.getInjector().getInstance(EnvironmentVariables.class);
+	    String tagsExpression = ThucydidesSystemProperty.TAGS.from(environmentVariables, "");
+	    List<String> existingTagsValues = existingTags.stream().map(Object::toString).collect(toList());
+	    return Splitter.on(",").trimResults().omitEmptyStrings().splitToList(tagsExpression).stream()
+	            .map(CucumberWithSerenityRuntime::toCucumberTag).filter(t -> !existingTagsValues.contains(t)).collect(toList());
+	}
+
+
+	public static String toCucumberTag(String from) {
+	    String tag = from.replaceAll(":", "=");
+	    if (tag.startsWith("~@") || tag.startsWith("@")) {
+	        return tag;
+	    }
+	    if (tag.startsWith("~")) {
+	        return "~@" + tag.substring(1);
+	    }
+	
+	    return "@" + tag;
+	}
+
 }

--- a/src/main/java/net/serenitybdd/cucumber/LiteralExpression.java
+++ b/src/main/java/net/serenitybdd/cucumber/LiteralExpression.java
@@ -1,4 +1,4 @@
-package io.cucumber.junit;
+package net.serenitybdd.cucumber;
 
 import io.cucumber.tagexpressions.Expression;
 

--- a/src/main/java/net/serenitybdd/cucumber/cli/Main.java
+++ b/src/main/java/net/serenitybdd/cucumber/cli/Main.java
@@ -4,7 +4,6 @@ import io.cucumber.core.options.CommandlineOptionsParser;
 import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.resource.ClassLoaders;
 import io.cucumber.core.runtime.Runtime;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
 import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 
 import java.io.IOException;
@@ -21,7 +20,7 @@ public class Main {
 
     public static byte run(String[] argv, Supplier<ClassLoader> classLoaderSupplier) throws IOException {
         RuntimeOptions  runtimeOptions = new CommandlineOptionsParser(System.out).parse(argv).build() ;
-        CucumberWithSerenity.setRuntimeOptions(runtimeOptions);
+        CucumberWithSerenityRuntime.setRuntimeOptions(runtimeOptions);
         Runtime runtime = CucumberWithSerenityRuntime.using(classLoaderSupplier, runtimeOptions);
 
         runtime.run();

--- a/src/main/java/net/serenitybdd/cucumber/integration/intellij/CucumberWithSerenityRuntimeMain.java
+++ b/src/main/java/net/serenitybdd/cucumber/integration/intellij/CucumberWithSerenityRuntimeMain.java
@@ -4,7 +4,7 @@ import io.cucumber.core.options.CommandlineOptionsParser;
 import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.resource.ClassLoaders;
 import io.cucumber.core.runtime.Runtime;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 import net.thucydides.core.guice.Injectors;
 import net.thucydides.core.webdriver.Configuration;
 
@@ -42,7 +42,7 @@ public class CucumberWithSerenityRuntimeMain {
         //ResourceLoader resourceLoader = new MultiLoader(classLoader);
         Configuration systemConfiguration = Injectors.getInjector().getInstance(Configuration.class);
         //Supplier<ClassLoader> classLoader = ClassLoaders::getDefaultClassLoader;
-        Runtime serenityRuntime = CucumberWithSerenity.createSerenityEnabledRuntime(/*resourceLoader,*/
+        Runtime serenityRuntime = CucumberWithSerenityRuntime.createSerenityEnabledRuntime(/*resourceLoader,*/
                 classLoaderSupplier,
                 runtimeOptions,
                 systemConfiguration);

--- a/src/main/java/net/serenitybdd/cucumber/model/StoredFeatureFile.java
+++ b/src/main/java/net/serenitybdd/cucumber/model/StoredFeatureFile.java
@@ -1,6 +1,6 @@
 package net.serenitybdd.cucumber.model;
 
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,7 +47,7 @@ public class StoredFeatureFile {
     
 
     public File fromTheConfiguredPaths() throws IOException {
-        for(URI uri : CucumberWithSerenity.currentRuntimeOptions().getFeaturePaths()) {
+        for(URI uri : CucumberWithSerenityRuntime.currentRuntimeOptions().getFeaturePaths()) {
             if (Files.exists(candidatePath(uri, featureFileName))) {
                 return candidatePath(uri, featureFileName).toFile();
             }

--- a/src/test/java/io/cucumber/junit/CucumberRunner.java
+++ b/src/test/java/io/cucumber/junit/CucumberRunner.java
@@ -5,7 +5,7 @@ import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.options.RuntimeOptionsBuilder;
 import io.cucumber.core.resource.ClassLoaders;
 import io.cucumber.core.runtime.Runtime;
-import net.serenitybdd.cucumber.CucumberWithSerenity;
+import net.serenitybdd.cucumber.CucumberWithSerenityRuntime;
 import net.thucydides.core.configuration.SystemPropertiesConfiguration;
 import net.thucydides.core.util.EnvironmentVariables;
 import net.thucydides.core.util.SystemEnvironmentVariables;
@@ -43,7 +43,7 @@ public class CucumberRunner {
         Configuration systemConfiguration = new SystemPropertiesConfiguration(environmentVariables);
         systemConfiguration.setOutputDirectory(outputDirectory);
         Supplier<ClassLoader> classLoaderSupplier = ClassLoaders::getDefaultClassLoader;
-        return CucumberWithSerenity.createSerenityEnabledRuntime(classLoaderSupplier, annotationOptions, systemConfiguration);
+        return CucumberWithSerenityRuntime.createSerenityEnabledRuntime(classLoaderSupplier, annotationOptions, systemConfiguration);
     }
 
     public static Runtime serenityRunnerForCucumberTestRunner(Class testClass, Configuration systemConfiguration) {
@@ -59,7 +59,7 @@ public class CucumberRunner {
                 addDefaultSummaryPrinterIfAbsent(). build(annotationOptions);
 
         Supplier<ClassLoader> classLoaderSupplier = ClassLoaders::getDefaultClassLoader;
-        return CucumberWithSerenity.createSerenityEnabledRuntime( classLoaderSupplier,  runtimeOptionsBuilder, systemConfiguration);
+        return CucumberWithSerenityRuntime.createSerenityEnabledRuntime( classLoaderSupplier,  runtimeOptionsBuilder, systemConfiguration);
     }
 
 }


### PR DESCRIPTION
I try to use serenity with cucumber-junit-platform-engine. This applies equally to serenity-cucumber5 and serenity-cucumber6, as the assumption that cucumber scenarios are launched from junit4 still holds and creates exactly the same problems.

I have published a reproduction example: https://github.com/nicerloop/serenity-cucumber-starter/tree/use-cucumber-junit-platform-engine

https://github.com/serenity-bdd/serenity-cucumber6/issues/35